### PR TITLE
remove `andThen` helper

### DIFF
--- a/tests/acceptance/let-helper-test.js
+++ b/tests/acceptance/let-helper-test.js
@@ -24,41 +24,39 @@ describe('Acceptance: let helper', function() {
   });
 
   it('binds basic values', () => {
-    andThen(() => {
-      expect(find('ul.basic li:first').text()).to.equal('abc');
-      expect(find('ul.basic li:last').text()).to.equal('123');
-    });
+    expect(find('ul.basic li:first').text()).to.equal('abc');
+    expect(find('ul.basic li:last').text()).to.equal('123');
   });
 
   it('binds nested values', () => {
-    andThen(() => {
-      let expected = ['first', 'second', 'third'];
+    let expected = ['first', 'second', 'third'];
 
-      find('ul.with-hash li').each((i, v) => {
-        expect($(v).text()).to.equal(expected[i]);
-      });
+    find('ul.with-hash li').each((i, v) => {
+      expect($(v).text()).to.equal(expected[i]);
     });
   });
 
-  it('binds class instances', () => {
-    andThen(() => {
+  describe('binding css classes', ()=> {
+    it('starts out with one value', ()=> {
       expect(find('.with-helper-object #bool-value').text()).to.equal('false');
     });
 
-    click('button#toggle-bool');
+    describe('toggling the boolean', function() {
+      beforeEach(function() {
+        click('button#toggle-bool');
+      });
 
-    andThen(() => {
-      expect(find('.with-helper-object #bool-value').text()).to.equal('true');
+      it('changes the value', function() {
+        expect(find('.with-helper-object #bool-value').text()).to.equal('true');
+      });
     });
   });
 
   it('will yield its block even when the value is falsey', () => {
     let expected = ['this is undefined', 'this is null', 'this is an empty array'];
 
-    andThen(() => {
-      find('.missing-values li').each((i, v) => {
-        expect($(v).text()).to.equal(expected[i]);
-      });
+    find('.missing-values li').each((i, v) => {
+      expect($(v).text()).to.equal(expected[i]);
     });
   });
 

--- a/tests/acceptance/let-helper-test.js
+++ b/tests/acceptance/let-helper-test.js
@@ -23,12 +23,12 @@ describe('Acceptance: let helper', function() {
     destroyApp(application);
   });
 
-  it('binds basic values', () => {
+  it('binds basic values', function()  {
     expect(find('ul.basic li:first').text()).to.equal('abc');
     expect(find('ul.basic li:last').text()).to.equal('123');
   });
 
-  it('binds nested values', () => {
+  it('binds nested values', function() {
     let expected = ['first', 'second', 'third'];
 
     find('ul.with-hash li').each((i, v) => {
@@ -52,7 +52,7 @@ describe('Acceptance: let helper', function() {
     });
   });
 
-  it('will yield its block even when the value is falsey', () => {
+  it('will yield its block even when the value is falsey', function() {
     let expected = ['this is undefined', 'this is null', 'this is an empty array'];
 
     find('.missing-values li').each((i, v) => {
@@ -60,67 +60,68 @@ describe('Acceptance: let helper', function() {
     });
   });
 
-  if (emberVersionIs('greaterThan', "2.0.0")) {
-    describe('inline', () => {
+  if (emberVersionIs('greaterThan', '2.0.0')) {
+    describe('inline usage', function() {
 
-      it('works', () => {
-        andThen(() => {
-          expect(find('.inline-use').text()).to.equal("hello ");
+      it('works', function() {
+        expect(find('.inline-use').text()).to.equal('hello ');
+      });
+
+      describe('triggering a recomputation', function() {
+        beforeEach(function() {
+          click('button:contains(Greet the world)');
         });
 
-        click('button:contains(Greet the world)');
-
-        andThen(() => {
-          expect(find('.inline-use').text()).to.equal("hello world");
+        it('updates the binding', function() {
+          expect(find('.inline-use').text()).to.equal('hello world');
         });
       });
 
-      it('respects scoping rules', () => {
-        andThen(() => {
 
-          let result = find('.inline-scoping li').map(function() {
-            return $(this).text().trim();
-          }).toArray();
+         it('respects scoping rules', function() {
+        let result = find('.inline-scoping li').map(function() {
+          return $(this).text().trim();
+        }).toArray();
 
-          expect(result).to.deep.equal([
-            'num = 0',
-            'num = 1',
-            'num = 2',
-            'num = 3',
-            'num = 0'
-          ]);
-        });
+        expect(result).to.deep.equal([
+          'num = 0',
+          'num = 1',
+          'num = 2',
+          'num = 3',
+          'num = 0'
+        ]);
       });
 
-      it('scopes to outmost scope', () => {
-        andThen(() => {
+      it('scopes to outmost scope', function() {
+        let result = find('.inline-hoisting li').map(function() {
+          return $(this).text().trim();
+        }).toArray();
 
-          let result = find('.inline-hoisting li').map(function() {
-            return $(this).text().trim();
-          }).toArray();
-          
-          expect(result).to.deep.equal([
-            '0',
-            '1',
-            '2',
-            '3',
-            '0'
-          ]);
-        });
+        expect(result).to.deep.equal([
+          '0',
+          '1',
+          '2',
+          '3',
+          '0'
+        ]);
       });
 
-      it('supports multipe binding', function(){
-        andThen(() => {
+      describe('multiple binding', function(){
+        it('works', function() {
           expect($('.inline-multiple-binding .result').text()).to.equal('ember-let ');
         });
-      
-        click('button:contains(Show Addon Description)');
 
-        andThen(() => {
-          expect($('.inline-multiple-binding .result').text()).to.equal('ember-let variable declaration inspired by LISP');
+        describe('triggering a recomputation', function() {
+          beforeEach(function() {
+            click('button:contains(Show Addon Description)');
+          });
+
+          it('recomputes all bound values', function() {
+            expect($('.inline-multiple-binding .result').text()).to.equal('ember-let variable declaration inspired by LISP');
+          });
         });
       });
-      
+
     });
   }
 

--- a/tests/acceptance/let-helper-test.js
+++ b/tests/acceptance/let-helper-test.js
@@ -38,7 +38,7 @@ describe('Acceptance: let helper', function() {
 
   describe('binding css classes', ()=> {
     it('starts out with one value', ()=> {
-      expect(find('.with-helper-object #bool-value').text()).to.equal('false');
+      expect(find('#bool-value').text()).to.equal('false');
     });
 
     describe('toggling the boolean', function() {
@@ -47,7 +47,7 @@ describe('Acceptance: let helper', function() {
       });
 
       it('changes the value', function() {
-        expect(find('.with-helper-object #bool-value').text()).to.equal('true');
+        expect(find('#bool-value').text()).to.equal('true');
       });
     });
   });


### PR DESCRIPTION
BDD style encourages the explicit separation of actions and consequences. Actions are initiated in  the `beforeEach` blocks associated with the `describe` describing the action, and consequences are verified inside the `it` block.

The general rule is that `it` should have no side-effects.
