### PR TITLE
[BREAKING] Switch inline {{let}} to hash syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See examples below:
 Note: requires Ember 2.0+ (ie. does not support 1.13)
 
 ```hbs
-{{let greeting (concat "hello " to)}}
+{{let greeting=(concat "hello " to)}}
 {{greeting}} - <button {{action (action (mut to) "world")}}>Greet the world!</button>  
 ```
 
@@ -46,7 +46,7 @@ Inline let declarations are in scope until the parent element or block is closed
 ```
 {{#if person.isActive}}
   <div>
-    {{let name person.name}}
+    {{let name=person.name}}
     <span>{{name}}</span>
   </div>
   {{!-- The name binding is not accessible here... --}}

--- a/lib/inline-let-transform.js
+++ b/lib/inline-let-transform.js
@@ -3,15 +3,15 @@
   For example,
 
   ```hbs
-  {{let "activeMembers" (filter-by members 'active')}}
+  {{let activeMembers=(filter-by members 'active')}}
 
   <ul>
     {{#each activeMembers as |member|}}
       <li>
-        {{let name (format-member-name member)}}
+        {{let name=(format-member-name member)}}
         <div>Name: {{name}}</div>
 
-        {{let address (format-address member.address)}}
+        {{let address=(format-address member.address)}}
         <div>Address: {{address}}</div>
       </li>
     {{/each}}
@@ -81,12 +81,11 @@ InlineLetTransform.prototype.transform = function(ast) {
   function extractBindings(statement) {
     var bindings = { locals: [], values: [] };
 
-    var params = statement.params;
-    if (params) {
-      for (var i = 0; i < params.length; i += 2) {
-        bindings.locals.push(params[i].original);
-        bindings.values.push(params[i+1]);
-      }
+    if (statement.hash) {
+      statement.hash.pairs.forEach(function(pair) {
+        bindings.locals.push(pair.key);
+        bindings.values.push(pair.value);
+      })
     }
 
     return bindings;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -34,13 +34,13 @@
 </ul>
 
 <h3>Inline use</h3>
-{{let greeting (concat "hello " to)}}
+{{let greeting=(concat "hello " to)}}
 <div class="inline-use">{{greeting}}</div>
 <button {{action (action (mut to) "world")}}>Greet the world!</button>  
 
 <h3>Inline `let` respects scoping rules</h3>
 <div class="inline-scoping">
-  {{let num 0}}
+  {{let num=0}}
   <ul>
     <li>num = {{num}}</li>
     {{#each (array 1 2 3) as |num|}}

--- a/tests/integration/let-test.js
+++ b/tests/integration/let-test.js
@@ -22,7 +22,7 @@ describeComponent('let', 'Integration: let helper', {
 
     it('does not mutate the context', function(){
       this.set('name', 'Alice');
-      this.render(hbs`{{let name "Bob"}}`);
+      this.render(hbs`{{let name="Bob"}}`);
       expect(this.get('name')).to.eq('Alice');
     });
 
@@ -31,7 +31,7 @@ describeComponent('let', 'Integration: let helper', {
       this.render(hbs`
         <span class="before">{{type}}</span>
         {{#each pets as |pet|}}
-          {{let type pet.type}}
+          {{let type=pet.type}}
           <span class="item">{{type}}</span>
         {{/each}}
         <span class="after">{{type}}</span>
@@ -45,9 +45,9 @@ describeComponent('let', 'Integration: let helper', {
     it('creates bindings in parallel', function(){
       this.set('pets', [{ type: 'cat' }, { type: 'dog' }, { type: 'pig' }]);
       this.render(hbs`
-        {{let a 'a' b 'b'}}
+        {{let a='a' b='b'}}
         <span class="before">{{a}} {{b}}</span>
-        {{let a 'A' b 'B' c (concat a b)}}
+        {{let a='A' b='B' c=(concat a b)}}
         <span class="after">{{a}} {{b}} {{c}}</span>
       `);
 


### PR DESCRIPTION
Now you write

``` hbs
{{let a=1 b=2}}
```

instead of

``` hbs
{{let a 1 b 2}}
```

---

@cowboyd said it was alright to do a breaking change and bump to v0.5.0.
