### PR TITLE
Add baseDir to index.js to silence htmlbars caching deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,16 @@ module.exports = {
 
     registry.add('htmlbars-ast-plugin', {
       name: 'inline-let',
-      plugin: require('./lib/inline-let-transform')
+      plugin: require('./lib/inline-let-transform'),
+      baseDir: function() {
+        return __dirname;
+      }
     });
   },
 
   included: function(app) {
     this._super.included.apply(app, arguments);
-    
+
     app.import('vendor/ember-let/register.js');
   }
 };


### PR DESCRIPTION
Basically just stealing [this fix](https://github.com/offirgolan/ember-cp-validations/pull/305) from `ember-cp-validations` to fix the same deprecation.
