### PR TITLE
Update ember-cli-version-checker usage to allow ember-source npm package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   setupPreprocessorRegistry: function(type, registry) {
     // Inline let is only supported in Ember 2.0 and up.
     var checker = new VersionChecker(this);
-    if (checker.for('ember', 'bower').lt('2.0.0')) {
+    if (checker.forEmber().lt('2.0.0')) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-version-checker": "^1.1.6"
+    "ember-cli-version-checker": "^1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Update usage of ember-cli-version-checker to allow easier checking of Ember versions between ember bower package and ember-source npm package.