### PR TITLE
Load after ember-cli-shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-cli-version-checker": "^1.1.6"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-shims"
   }
 }


### PR DESCRIPTION
Since ember-cli-shims is not a bower dependency anymore, it loads later, causing the `ember` module to not be available to add-ons that rely on it.