### PR TITLE
add explicit support for Ember LTS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ cache:
 env:
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.0
+  - EMBER_TRY_SCENARIO=ember-2.4
+  - EMBER_TRY_SCENARIO=ember-2.8
+  - EMBER_TRY_SCENARIO=ember-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 env:
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-2.0
   - EMBER_TRY_SCENARIO=ember-2.4
   - EMBER_TRY_SCENARIO=ember-2.8
   - EMBER_TRY_SCENARIO=ember-2.12

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -24,22 +24,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-2.0',
-      bower: {
-        dependencies: {
-          'ember': '~2.0.0'
-        },
-        resolutions: {
-          'ember': '~2.0.0'
-        }
-      },
-      npm: {
-        dependencies: {
-          "ember-hash-helper-polyfill": "0.1.1"
-        }
-      }
-    },
-    {
       name: 'ember-2.4',
       bower: {
         dependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -16,6 +16,11 @@ module.exports = {
         resolutions: {
           'ember': '~1.13.0'
         }
+      },
+      npm: {
+        dependencies: {
+          "ember-hash-helper-polyfill": "0.1.1"
+        }
       }
     },
     {
@@ -27,38 +32,10 @@ module.exports = {
         resolutions: {
           'ember': '~2.0.0'
         }
-      }
-    },
-    {
-      name: 'ember-2.1',
-      bower: {
+      },
+      npm: {
         dependencies: {
-          'ember': '~2.1.0'
-        },
-        resolutions: {
-          'ember': '~2.1.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2.2',
-      bower: {
-        dependencies: {
-          'ember': '~2.2.0'
-        },
-        resolutions: {
-          'ember': '~2.2.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2.3',
-      bower: {
-        dependencies: {
-          'ember': '~2.3.0'
-        },
-        resolutions: {
-          'ember': '~2.3.0'
+          "ember-hash-helper-polyfill": "0.1.1"
         }
       }
     },
@@ -74,24 +51,24 @@ module.exports = {
       }
     },
     {
-      name: 'ember-2.5',
+      name: 'ember-2.8',
       bower: {
         dependencies: {
-          'ember': '~2.5.0'
+          'ember': '~2.8.0'
         },
         resolutions: {
-          'ember': '~2.5.0'
+          'ember': '~2.8.0'
         }
       }
     },
     {
-      name: 'ember-2.6',
+      name: 'ember-2.12',
       bower: {
         dependencies: {
-          'ember': '~2.6.0'
+          'ember': '~2.12.0'
         },
         resolutions: {
-          'ember': '~2.6.0'
+          'ember': '~2.12.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-data": "^2.6.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-hash-helper-polyfill": "0.1.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-version-is": "0.0.3",


### PR DESCRIPTION
Since those are the major waypoints where people stop on Ember mountain, let's at least check that they work with every LTS release.